### PR TITLE
Evan Piro Submission

### DIFF
--- a/src/api/routes/v1/people/index.js
+++ b/src/api/routes/v1/people/index.js
@@ -1,6 +1,4 @@
-const statusCodes = require('../../../lib/httpStatusCodes')
-const httpErrorMessages = require('../../../lib/httpErrorMessages')
-const { database } = require('../../../lib/database')
+const model = require('./model.js')
 
 module.exports = (api) => {
   /**
@@ -8,9 +6,7 @@ module.exports = (api) => {
    * Create a new person
    */
   api.post('/', async (req, res, next) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    model.create('people', req.body, res)
   })
 
   /**
@@ -18,9 +14,7 @@ module.exports = (api) => {
    * Retrieve a person by their ID
    */
   api.get('/:personID', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    model.find('people', { id: req.params.personID }, res)
   })
 
   /**
@@ -28,9 +22,7 @@ module.exports = (api) => {
    * Retrieve a list of people
    */
   api.get('/', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    model.search('people', {}, res)
   })
 
   /**
@@ -45,9 +37,9 @@ module.exports = (api) => {
    * Create a new address belonging to a person
    **/
   api.post('/:personID/addresses', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    let address = req.body
+    address.person_id = req.params.personID
+    model.create('addresses', address, res)
   })
 
   /**
@@ -55,9 +47,13 @@ module.exports = (api) => {
    * Retrieve an address by it's addressID and personID
    **/
   api.get('/:personID/addresses/:addressID', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    let {
+      personID: person_id,
+      addressID: id
+    } = req.params
+
+    let criteria = { person_id, id }
+    model.find('addresses', criteria, res)
   })
 
   /**
@@ -65,9 +61,8 @@ module.exports = (api) => {
    * List all addresses belonging to a personID
    **/
   api.get('/:personID/addresses', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    const person_id = req.params.personID
+    model.search('addresses', { person_id }, res)
   })
 
   /**
@@ -78,8 +73,12 @@ module.exports = (api) => {
    * Update the previous GET endpoints to omit rows where deleted_at is not null
    **/
   api.delete('/:personID/addresses/:addressID', async (req, res) => {
-    res
-      .status(statusCodes.NotImplemented)
-      .json(httpErrorMessages.NotImplemented)
+    let {
+      personID: person_id,
+      addressID: id
+    } = req.params
+
+    let criteria = { person_id, id }
+    model.remove('addresses', criteria, res)
   })
 }

--- a/src/api/routes/v1/people/model.js
+++ b/src/api/routes/v1/people/model.js
@@ -1,0 +1,139 @@
+const moment = require('moment');
+const statusCodes = require('../../../lib/httpStatusCodes')
+const { database } = require('../../../lib/database')
+
+/**
+ * Creates an entity and sends it to client.
+ *
+ * @param {string} type
+ *   Type of entity being created.
+ * @param {object} content
+ *   Content of the entity.
+ * @param {object} res
+ *   Express.js response object.
+ **/
+const create = (type, content, res) => {
+  database(type)
+    .insert(content)
+    .returning('*')
+    .then(([data]) => {
+      res
+        .type('application/json')
+        .status(statusCodes.OK)
+        .json(data)
+    })
+    .catch(error => {
+      res
+        .status(statusCodes.InternalServerError)
+        .json()
+    })
+}
+
+/**
+ * Finds most relevant entity based on a criteria and sends it to client.
+ *
+ * @param {string} type
+ *   Type of entity being created.
+ * @param {object} criteria
+ *   Object containing find criteria i.e { id: 33 }.
+ * @param {object} res
+ *   Express.js response object.
+ **/
+const find = (type, criteria, res) => {
+  database(type)
+    .select('*')
+    .where(criteria)
+    .whereNull('deleted_at')
+    .then( ([data]) => {
+      if (data){
+        res
+          .status(statusCodes.OK)
+          .type('application/json')
+          .json(data)
+      } else {
+        res
+          .status(statusCodes.NotFound)
+          .json()
+      }
+    })
+    .catch (error => {
+      res
+        .status(statusCodes.InternalServerError)
+        .json()
+    })
+}
+
+/**
+ * Searches for entities based on a criteria and sends entities to client.
+ *
+ * @param {string} type
+ *   Type of entity being created.
+ * @param {object} criteria
+ *   Object containing search criteria i.e { company: 'Mantl', title: 'Application Engineer' }.
+ * @param {object} res
+ *   Express.js response object.
+ **/
+const search = (type, criteria, res) => {
+  database(type)
+    .select('*')
+    .where(criteria)
+    .whereNull('deleted_at')
+    .then((data) => {
+      if (data.length){
+        res
+          .status(statusCodes.OK)
+          .type('application/json')
+          .json(data)
+      } else {
+        res
+          .status(statusCodes.NoContent)
+          .json()
+      }
+    })
+    .catch (error => {
+      res
+        .status(statusCodes.InternalServerError)
+        .json()
+    })
+}
+
+/**
+ * Sets entities to deleted state based on a criteria.
+ *
+ * @param {string} type
+ *   Type of entity being created.
+ * @param {object} criteria
+ *   Object containing search criteria.
+ * @param {object} res
+ *   Express.js response object.
+ **/
+const remove = (type, criteria, res) => {
+  // Failsafe for when a client attempts to delete all entities.
+  if (Object.keys(criteria).length === 0) {
+    res
+      .status(statusCodes.Unauthorized)
+      .json()
+  } else {
+    database(type)
+      .update({ 'deleted_at': moment().format() })
+      .where(criteria)
+      .then(() => {
+        res
+          .type('application/json')
+          .status(statusCodes.OK)
+          .json()
+      })
+      .catch(error => {
+        res
+          .status(statusCodes.InternalServerError)
+          .json()
+      })
+  }
+}
+
+module.exports = {
+  create,
+  find,
+  search,
+  remove,
+}

--- a/src/api/sql/migrations/V1566943365_create_people_table.sql
+++ b/src/api/sql/migrations/V1566943365_create_people_table.sql
@@ -11,3 +11,15 @@
  * updated_at timestamp with timezone
  * deleted_at timestamp with timezone
  ***/
+CREATE TABLE people
+(
+    id BIGSERIAL PRIMARY KEY,
+    first_name varchar(256) NOT NULL,
+    last_name varchar(256) NOT NULL,
+    birthday date,
+    company varchar(256),
+    title varchar(256),
+    created_at timestamptz NOT NULL DEFAULT current_timestamp,
+    updated_at timestamptz,
+    deleted_at timestamptz
+)

--- a/src/api/sql/migrations/V1566943370_create_addresses_table.sql
+++ b/src/api/sql/migrations/V1566943370_create_addresses_table.sql
@@ -12,3 +12,16 @@
  * updated_at timetsamp with timezone
  * deleted_at timetsamp with timezone
  ***/
+CREATE TABLE addresses
+(
+    id  BIGSERIAL PRIMARY KEY,
+    person_id BIGINT       NOT NULL REFERENCES people,
+    line1 varchar(256) NOT NULL,
+    line2 varchar(256),
+    city varchar(256) NOT NULL,
+    state varchar(256) NOT NULL,
+    zip varchar(256) NOT NULL,
+    created_at timestamptz  NOT NULL DEFAULT current_timestamp,
+    updated_at timestamptz,
+    deleted_at timestamptz
+)

--- a/src/api/tests/fixtures/index.js
+++ b/src/api/tests/fixtures/index.js
@@ -24,9 +24,19 @@ const firstPerson = {
   created_at: moment().toISOString()
 }
 
+const firstAddress = {
+  line1: faker.address.streetAddress(),
+  line2: faker.address.secondaryAddress(),
+  city: faker.address.city(),
+  state: faker.address.state(),
+  zip: faker.address.zipCode(),
+
+}
+
 module.exports = {
   contentTypes,
   firstPerson,
+  firstAddress,
   peopleSchema,
   addressesSchema,
   passingRootServerResponse,

--- a/src/api/tests/people.spec.js
+++ b/src/api/tests/people.spec.js
@@ -2,6 +2,7 @@ const fixtures = require('./fixtures')
 const httpStatusCodes = require('../lib/httpStatusCodes')
 const { client } = require('./setup/supertestServer')
 const { expect } = require('chai')
+const moment = require ('moment')
 
 describe('People API', () => {
   it('POST /v1/people should create a new person', async () => {
@@ -44,10 +45,42 @@ describe('People API', () => {
    * ======================================================
    */
 
-  it('POST /v1/people/:personID/addresses should create a new address')
-  it('GET /v1/people/:personID/addresses/:addressID should return an address by its id and its person_id')
-  it('GET /v1/people/:personID/addresses should return a list of addresses belonging to the person by that id')
+  it('POST /v1/people/:personID/addresses should create a new address', async () => {
+    await client
+      .post(`/v1/people/${fixtures.firstPerson.id}/addresses`)
+      .send(fixtures.firstAddress)
+      .expect(httpStatusCodes.OK)
+      .then(resp => {
+        fixtures.firstAddress = resp.body
+      })
+  })
+
+  it('GET /v1/people/:personID/addresses/:addressID should return an address by its id and its person_id', async () => {
+    await client
+      .get(`/v1/people/${fixtures.firstPerson.id}/addresses/${fixtures.firstAddress.id}`)
+      .expect(httpStatusCodes.OK, fixtures.firstAddress)
+  })
+
+  it('GET /v1/people/:personID/addresses should return a list of addresses belonging to the person by that id', async () => {
+    await client
+      .get(`/v1/people/${fixtures.firstPerson.id}/addresses`)
+      .expect('Content-Type', fixtures.contentTypes.json)
+      .expect(httpStatusCodes.OK)
+      .then(resp => {
+        expect(resp.body).to.have.lengthOf.above(0)
+      })
+  })
 
   // BONUS!!!
-  it('DELETE /v1/people/:personID/addresses/:addressID should delete an address by its id (BONUS)')
+  it('DELETE /v1/people/:personID/addresses/:addressID should delete an address by its id (BONUS)', async () => {
+    await client
+      .delete(`/v1/people/${fixtures.firstPerson.id}/addresses/${fixtures.firstAddress.id}`)
+      .expect(httpStatusCodes.OK)
+  })
+
+  it('GET /v1/people/:personID/addresses/:addressID should not show a deleted address', async () => {
+    await client
+      .get(`/v1/people/${fixtures.firstPerson.id}/addresses/${fixtures.firstAddress.id}`)
+      .expect(httpStatusCodes.NotFound)
+  })
 })


### PR DESCRIPTION
# Strategy
My intentions for the implementation here were to keep the routing area clean and to create a discrete set of reusable functions that abstract away a lot of the somewhat repetitive code blocks I began to observe while developing this. If I could treat an address object and a person object as a generic entity and derive the needed actions for the implementation, then I could move most of the data-driven complexity from the routing layer into something akin to a model in an MVC (of course I didn't go that far). The following actions I found to encompass the needs of the implementation:
1. Create - Manages the creation of entities.
2. Find - Finds a single entity by a search criteria.
3. Search - Searches across entities and returns a list.
4. Remove - Removes entities based on a criteria.

## To Do (Hypothetical)
- Remove the need for an express response object injected into the functions in `model.js` and move the file outside of the `api/routes/v1/people` directory into something like `api/model`. Responding to requests should be the sole responsibility of the routing layer while management of the data should belong to the model. 
- Add [chai-json-schema](https://www.chaijs.com/plugins/chai-json-schema/) to the tests and implement type checking on address and people objects.
