### PR TITLE
WIP update all the things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:10-stretch
+FROM node:16-buster
 
 WORKDIR /opt/app
 
 RUN apt-get update && \
     apt-get install -y \
-  	build-essential \
-		postgresql-client-9.6
+		postgresql-client
 
 # Install Monarch
 RUN curl -o /usr/local/bin/monarch https://cdn.mantl.team/assets/binaries/monarch/linux-8790d0f \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   postgres:
-    image: 'postgres:9.6'
+    image: 'postgres:14'
 
     env_file:
       - .env

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1",
     "express-enrouten": "^1.3.0",
-    "faker": "^4.1.0",
-    "jest": "^24.9.0",
-    "knex": "^0.19.2",
-    "mocha": "^6.2.0",
+    "faker": "^5.5.3",
+    "jest": "^27.3.1",
+    "knex": "^0.95.12",
+    "mocha": "^9.1.3",
     "moment": "^2.24.0",
-    "nodemon": "^1.19.1",
-    "pg": "^7.12.1",
+    "nodemon": "^2.0.14",
+    "pg": "^8.7.1",
     "pg-native": "^3.0.0",
-    "supertest": "^4.0.2"
+    "supertest": "^6.1.6"
   }
 }


### PR DESCRIPTION
The repo stopped working once  node-gyp dropped support for Python <3.6.
This basically updates everything to the latest LTS' (Node, Debian, Psql, NPM deps).
I hit a wall because the `monarch` lib, which is used to run the db migrations, needs it's psql drivers updated to understand the new auth protocols.